### PR TITLE
feat: accept a pre-built Faraday connection

### DIFF
--- a/lib/ms_graph_rest.rb
+++ b/lib/ms_graph_rest.rb
@@ -47,7 +47,7 @@ class Faraday::FileReadAdapter < Faraday::Adapter
     data = File.read(filename(method, path, filename))
     save_response(env, 200, data)
   rescue Errno::ENOENT => e
-    save_response(env, 418, { 'error' => e.message })
+    save_response(env, 418, MultiJson.dump('error' => e.message))
   end
 
   private

--- a/lib/ms_graph_rest.rb
+++ b/lib/ms_graph_rest.rb
@@ -79,7 +79,12 @@ module MsGraphRest
     attr_reader :auth_callback
     attr_reader :faraday_adapter
 
-    def initialize(auth_callback:, faraday_adapter:)
+    # Pass `conn` to use a pre-built Faraday connection instead of building one
+    # from auth_callback/faraday_adapter. The connection must raise
+    # Faraday::Error subclasses for non-2xx responses (e.g. via
+    # Faraday::Response::RaiseError) for error wrapping to work.
+    def initialize(auth_callback: nil, faraday_adapter: nil, conn: nil)
+      @conn = conn
       @auth_callback = auth_callback
       @faraday_adapter = faraday_adapter
     end
@@ -138,9 +143,17 @@ module MsGraphRest
   class Client
     attr_reader :connection
 
-    def initialize(access_token:, faraday_adapter: Faraday.default_adapter, auth_callback: nil)
-      auth_callback ||= ->(c) { c.request :authorization, 'Bearer', access_token }
-      @connection = FaradayConnection.new(auth_callback: auth_callback, faraday_adapter: faraday_adapter)
+    # Build with either a pre-built Faraday connection (faraday_connection:) or
+    # the parameters to construct one (access_token:/auth_callback: plus
+    # faraday_adapter:).
+    def initialize(access_token: nil, faraday_adapter: Faraday.default_adapter, auth_callback: nil,
+                   faraday_connection: nil)
+      @connection = if faraday_connection
+                      FaradayConnection.new(conn: faraday_connection)
+                    else
+                      auth_callback ||= ->(c) { c.request :authorization, 'Bearer', access_token }
+                      FaradayConnection.new(auth_callback: auth_callback, faraday_adapter: faraday_adapter)
+                    end
     end
 
     def users

--- a/spec/ms_graph_rest_spec.rb
+++ b/spec/ms_graph_rest_spec.rb
@@ -18,6 +18,28 @@ RSpec.describe MsGraphRest do
       end
     end
 
+    context 'with an injected Faraday connection' do
+      subject { described_class.new(faraday_connection: faraday).connection }
+
+      let(:faraday) do
+        Faraday.new(url: 'https://graph.microsoft.com/v1.0/') do |c|
+          c.use Faraday::Response::RaiseError
+          c.adapter :test do |stub|
+            stub.get('/v1.0/me') { [200, { 'Content-Type' => 'application/json' }, '{"mail":"a@b.c"}'] }
+            stub.get('/v1.0/missing') { [404, {}, ''] }
+          end
+        end
+      end
+
+      it 'sends requests through the injected connection' do
+        expect(subject.get('me', {})).to eq('mail' => 'a@b.c')
+      end
+
+      it 'wraps Faraday errors raised by the injected connection' do
+        expect { subject.get('missing', {}) }.to raise_error(MsGraphRest::ResourceNotFound)
+      end
+    end
+
     context 'when parsing error' do
       subject { described_class.new(access_token: 'access_token').connection }
 


### PR DESCRIPTION
Client.new(faraday_connection:) / FaradayConnection.new(conn:) let callers supply their own Faraday connection (with its own middleware, auth, and timeouts) instead of having the gem build one from auth_callback + faraday_adapter. The connection must raise Faraday::Error for non-2xx responses for the existing error wrapping to apply.

Needed by On-Call Optimizer so Microsoft Graph requests run through its standard outbound transport stack (circuit breaking, logging, timeouts) — see the connection-failure-detection feature (US-003).

🤖 Generated with [Claude Code](https://claude.com/claude-code)